### PR TITLE
Preventing panic Crash

### DIFF
--- a/osm/smi/smi.go
+++ b/osm/smi/smi.go
@@ -160,7 +160,8 @@ func (test *SmiTest) installConformanceTool() error {
 	}
 
 	actionConfig := &action.Configuration{}
-	if err := actionConfig.Init(kube.GetConfig(test.kubeConfigPath, "", namespace), namespace, os.Getenv("HELM_DRIVER"), nil); err != nil {
+	nopLogger := func(_ string, _ ...interface{}) {} //Dummy logger for helm packages
+	if err := actionConfig.Init(kube.GetConfig(test.kubeConfigPath, "", namespace), namespace, os.Getenv("HELM_DRIVER"), nopLogger); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: dhruv0000 <patel.4@iitj.ac.in>

**Description**
Bug: The panic crash was because the logger passed in Helm packages was `nil`.
Solution: Sending a dummy logger, since we also handle logs in our package and the helm logs are nop.

This PR fixes #57 #55 

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
