### PR TITLE
Formatting time response to RFC3339

### DIFF
--- a/osm/smi/smi.go
+++ b/osm/smi/smi.go
@@ -94,7 +94,7 @@ func (test *SmiTest) Run(labels, annotations map[string]string) (Response, error
 
 	response := Response{
 		Id:                test.id,
-		Date:              time.Now().String(),
+		Date:              time.Now().Format(time.RFC3339),
 		MeshName:          test.adaptorName,
 		MeshVersion:       test.adaptorVersion,
 		CasesPassed:       "0",


### PR DESCRIPTION
Signed-off-by: dhruv0000 <patel.4@iitj.ac.in>

**Description**
UI uses momentJS which supports RFC3339 timestamp. Also the meshery performance test uses RFC3339 timestamp.
This PR fixes #

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
